### PR TITLE
Adding LLLLLLVAR length type to support 6-length variable fields

### DIFF
--- a/CSharp8583/CSharp8583/Common/Enumerations.cs
+++ b/CSharp8583/CSharp8583/Common/Enumerations.cs
@@ -125,7 +125,11 @@
         /// <summary>
         /// LLLLVAR binary field of up to 9999 bits in length
         /// </summary>
-        LLLLVAR = 4
+        LLLLVAR = 4,
+        /// <summary>
+        /// LLLLLLVAR binary field of up to 999999 bits in length
+        /// </summary>
+        LLLLLLVAR = 6
     }
 
     /// <summary>

--- a/CSharp8583/CSharp8583/Extensions/IsoExtensions.cs
+++ b/CSharp8583/CSharp8583/Extensions/IsoExtensions.cs
@@ -126,6 +126,7 @@ namespace CSharp8583.Extensions
                     case LengthType.LLVAR:
                     case LengthType.LLLVAR:
                     case LengthType.LLLLVAR:
+                    case LengthType.LLLLLLVAR:
                         if (isoFieldProperties.LenDataType == DataType.ASCII)
                         {
                             var lenValue = isoMessageBytes.Skip(currentPos).Take(lengthBytes).ToASCIIString(isoFieldProperties.Encoding);
@@ -206,6 +207,7 @@ namespace CSharp8583.Extensions
                     case LengthType.LLVAR:
                     case LengthType.LLLVAR:
                     case LengthType.LLLLVAR:
+                    case LengthType.LLLLLLVAR:
                         if (isoFieldProperties.LenDataType == DataType.ASCII)
                         {
                             var valueLen = fieldValue?.Length.ToString().PadLeft((int)isoFieldProperties.LengthType, '0');


### PR DESCRIPTION
Add support for LLLLLLVAR fields. These are used for the Postilion extensions to ISO 8583 in F127.
Field 127 is a message on its own - including a separate bitmap of subfields. This only allows us to extract the field's contents, not to parse it as part of this library.